### PR TITLE
Bump broccoli-esnext

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Robert Jackson <robert.w.jackson@me.com>",
   "license": "MIT",
   "dependencies": {
-    "broccoli-esnext": "~0.3.0"
+    "broccoli-esnext": "~0.4.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
`broccoli-esnext` now supports source maps: 
https://github.com/shinnn/broccoli-esnext/commit/d52b5f0e3f5280bcc5b890ca0f5cde3d71cd5a10
