### PR TITLE
Include regenerator runtime in addon tree

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 'use strict';
 
 var esNext = require('broccoli-esnext');
+var Regenerator = require('regenerator');
+var pickFiles = require('broccoli-static-compiler');
+var path = require('path');
 
 module.exports = {
   name: 'ember-cli-esnext',
@@ -13,6 +16,21 @@ module.exports = {
       toTree: function(tree) {
         return esNext(tree, app.options.esnextOptions);
       }
+    });
+  },
+  treeFor: function(type) {
+    if (type === 'addon') {
+      return this.regeneratorRuntimeTree();
+    }
+  },
+  regeneratorRuntimeTree: function() {
+    var dirname = path.dirname(Regenerator.runtime.path)
+    var file = path.basename(Regenerator.runtime.path);
+
+    return pickFiles(dirname, {
+      srcDir: '/',
+      files: [file],
+      destDir: '/'
     });
   }
 };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   "author": "Robert Jackson <robert.w.jackson@me.com>",
   "license": "MIT",
   "dependencies": {
-    "broccoli-esnext": "~0.5.0"
+    "broccoli-esnext": "~0.5.0",
+    "broccoli-static-compiler": "^0.2.1",
+    "regenerator": "^0.8.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds the regenerator runtime in the addon tree. I tried to use `app.import` but not get success due to some errors with glob and absolute paths, so I used the `treeFor` hook. At the moment the regenerator is always included, I think it's ok, because the runtime is small and all will works. I created this [repo](https://github.com/marcioj/esnext-test) if someone wants to test these changes, the [users/index route](https://github.com/marcioj/esnext-test/blob/master/app/routes/users/index.js#L11) is where the async await is used. 

Fixes #3
