### PR TITLE
Deprecate ember-cli-esnext

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+:warning: This addon is deprecated in favor of https://github.com/babel/ember-cli-babel :warning:
+
 ## ember-cli-esnext
 
 This addon inserts adds `esnext` processing into the javascript preprocessor for Ember CLI.


### PR DESCRIPTION
Since this addon is not used anymore, I think it's worth to deprecate it and point to the official addon.
What do you think @rwjblue ?
